### PR TITLE
Replaced EX_LOYAL_UNIT with appropriate mainline equivalents

### DIFF
--- a/macros/extended.cfg
+++ b/macros/extended.cfg
@@ -17,40 +17,6 @@
     {CLEAR_VARIABLE temp_EX_CAPTURE_VILLAGES_loc}
 #enddef
 
-# Lately I have had too much trouble as the result of changes to the mainline macros' parameter
-# order; therefore, here I have written overrides tailored to existing WML of this campaign; changing
-# the parameter order across 23 scenarios which make heavy use of macros is very difficult...
-
-#define EX_LOYAL_UNIT _UNIT_TYPE _ID _NAME _SIDE_NUM _XPOS _YPOS
-    [unit]
-        type={_UNIT_TYPE}
-        side={_SIDE_NUM}
-
-        x,y={_XPOS},{_YPOS}
-
-        id={_ID}
-        name={_NAME}
-
-        [modifications]
-            {TRAIT_LOYAL}
-        [/modifications]
-    [/unit]
-#enddef
-
-#define EX_LOYAL_UNDEAD_UNIT _UNIT_TYPE _SIDE_NUM _XPOS _YPOS
-    [unit]
-        type={_UNIT_TYPE}
-        side={_SIDE_NUM}
-
-        x,y={_XPOS},{_YPOS}
-
-        [modifications]
-            {TRAIT_LOYAL}
-            {TRAIT_UNDEAD}
-        [/modifications]
-    [/unit]
-#enddef
-
 #define RANDOM_SUBSCRIPT _ARRAY
     {RANDOM ("0..$($"+{_ARRAY}+".length - 1")}
 #enddef

--- a/scenarios/02_A_Real_Confrontation.cfg
+++ b/scenarios/02_A_Real_Confrontation.cfg
@@ -447,10 +447,10 @@
             message= _ "It must be that they are a new tribe, only recently come into its power... an evil power that is not from our world. Look!"
         [/message]
 
-        {EX_LOYAL_UNIT (Demon Zephyr) (Garya) ( _ "Garya") 5 5 33} {GENDER female} {FACING ne}
-        {EX_LOYAL_UNIT (Demon Zephyr) (Quiryn) ( _ "Quiryn") 5 4 32} {FACING ne}
+        {NAMED_LOYAL_UNIT 5 (Demon Zephyr)  5 33 (Garya) ( _ "Garya")} {GENDER female} {FACING ne}
+        {NAMED_LOYAL_UNIT 5 (Demon Zephyr) 4 32 (Quiryn) ( _ "Quiryn") } {FACING ne}
 #ifdef HARD
-        {EX_LOYAL_UNIT (Demon Zephyr) (Nolok) ( _ "Nolok") 5 4 33} {FACING ne}
+        {NAMED_LOYAL_UNIT 5 (Demon Zephyr) 4 33 (Nolok) ( _ "Nolok")} {FACING ne}
 #endif
 
         [scroll_to]

--- a/scenarios/05b_Cursed_Plateau.cfg
+++ b/scenarios/05b_Cursed_Plateau.cfg
@@ -118,14 +118,14 @@
 
         {VARIABLE took_ring no}
 
-        {EX_LOYAL_UNIT Demon () () 3 4 24}
-        {EX_LOYAL_UNIT Demon () () 3 8 31}
-        {EX_LOYAL_UNIT Imp () () 3 14 19}
-        {EX_LOYAL_UNIT (Psy Crawler) () () 2 23 21}
-        {EX_LOYAL_UNIT (Psy Crawler) () () 2 19 17}
-        {EX_LOYAL_UNIT (Chaos Hound) () () 3 19 11}
-        {EX_LOYAL_UNIT (Chaos Headhunter) () () 2 9 12}
-        {EX_LOYAL_UNIT (Chaos Headhunter) () () 2 12 15}
+        {LOYAL_UNIT 3 Demon 4 24}
+        {LOYAL_UNIT 3 Demon 8 31}
+        {LOYAL_UNIT 3 Imp 14 19}
+        {LOYAL_UNIT 2 (Psy Crawler) 23 21}
+        {LOYAL_UNIT 2 (Psy Crawler) 19 17}
+        {LOYAL_UNIT 3 (Chaos Hound) 19 11}
+        {LOYAL_UNIT 2 (Chaos Headhunter) 9 12}
+        {LOYAL_UNIT 2 (Chaos Headhunter) 12 15}
     [/event]
 
     [event]

--- a/scenarios/06_The_Moon_Valley.cfg
+++ b/scenarios/06_The_Moon_Valley.cfg
@@ -421,11 +421,11 @@
         [/message]
 
 #ifndef EASY
-        {EX_LOYAL_UNIT (Orcish Assassin) Turgan ( _ "Turgan") 3 14 12}
-        {EX_LOYAL_UNIT (Orcish Assassin) Akir ( _ "Akir") 3 21 9} {FACING sw}
+        {NAMED_LOYAL_UNIT 3 (Orcish Assassin) 14 12 Turgan ( _ "Turgan")}
+        {NAMED_LOYAL_UNIT 3 (Orcish Assassin) 21 9 Akir ( _ "Akir")} {FACING sw}
 #endif
 #ifdef HARD
-        {EX_LOYAL_UNIT (Orcish Assassin) Khur ( _ "Khur") 3 19 13} {FACING sw}
+        {NAMED_LOYAL_UNIT 3 (Orcish Assassin) 19 13 Khur ( _ "Khur")} {FACING sw}
 #endif
     [/event]
 


### PR DESCRIPTION
This replaced the redundant EX_LOYAL_UNIT with the mainline NAMED_LOYAL_UNIT or LOYAL_UNIT where applicable.