### PR TITLE
Refactored Healing Glyph execution

### DIFF
--- a/macros/items.cfg
+++ b/macros/items.cfg
@@ -162,68 +162,63 @@ halo/glyph-halo.png~O(0.[4,48,54,48]):[500,200*3] #enddef
             [option]
                 message={STR_YES}
                 [command]
-                    [object]
-                        name= _ "Crystal Glyph of Health"
-                        image=items/crystal-glyph.png
-                        description= _ "The unit is fully healed, cured and unslowed."
+                    [remove_item]
+                        x,y=$x1,$y1
+                    [/remove_item]
+
+                    [remove_terrain_overlays]
+                        x,y=$x1,$y1
+                    [/remove_terrain_overlays]
+
+                    [heal_unit]
                         [filter]
-                            side=1
                             x,y=$x1,$y1
                         [/filter]
+                        amount="full"
+                        animate=yes
+                        restore_statuses=yes
+                    [/heal_unit]
+
+                    [sound]
+                        name=heal.wav
+                    [/sound]
+
+                    [set_variables]
+                        mode=merge
+                        name=unit
+                        [literal]
+                            moves=0
+                        [/literal]
+                    [/set_variables]
+
+                    [if]
+                        {VARIABLE_LEXICAL_EQUALS unit.gender "female"}
                         [then]
-                            [remove_item]
-                                x,y=$x1,$y1
-                            [/remove_item]
-
-                            [remove_terrain_overlays]
-                                x,y=$x1,$y1
-                            [/remove_terrain_overlays]
-
-                            [heal_unit]
-                                [filter]
-                                    x,y=$x1,$y1
-                                [/filter]
-                                amount="full"
-                                animate=yes
-                                restore_statuses=yes
-                            [/heal_unit]
-
-                            [sound]
-                                name=heal.wav
-                            [/sound]
-
-                            [if]
-                                {VARIABLE_LEXICAL_EQUALS unit.gender "female"}
-                                [then]
-                                    {VARIABLE temp_OBJ_HEALING_GLYPH_msg _"female^healed"}
-                                [/then]
-                                [else]
-                                    {VARIABLE temp_OBJ_HEALING_GLYPH_msg _"healed"}
-                                [/else]
-                            [/if]
-
-                            [set_variables]
-                                mode=merge
-                                name=unit
-                                [literal]
-                                    moves=0
-                                [/literal]
-                            [/set_variables]
-
-                            [unstore_unit]
-                                variable=unit
-                                text=$temp_OBJ_HEALING_GLYPH_msg
-                                {COLOR_HEAL}
-                            [/unstore_unit]
-
-                            [redraw][/redraw]
-
-                            [event]
-                                id="OBJ_HEALING_GLYPH_impl_"+{_X}+"_"+{_Y} # wmllint: ignore
-                                remove=yes
-                            [/event]
+                            {VARIABLE temp_OBJ_HEALING_GLYPH_msg _"female^healed"}
                         [/then]
-                    [/object]
+                        [else]
+                            {VARIABLE temp_OBJ_HEALING_GLYPH_msg _"healed"}
+                        [/else]
+                    [/if]
+
+                    [unstore_unit]
+                        variable=unit
+                        text=$temp_OBJ_HEALING_GLYPH_msg
+                        {COLOR_HEAL}
+                    [/unstore_unit]
+
+                    [redraw][/redraw]
+
+                    [event]
+                        id="OBJ_HEALING_GLYPH_impl_"+{_X}+"_"+{_Y} # wmllint: ignore
+                        remove=yes
+                    [/event]
+
+                    [transient_message]
+                        caption= _ "Crystal Glyph of Health"
+                        image=items/crystal-glyph.png
+                        message= _ "The unit is fully healed, cured and unslowed."
+                    [/transient_message]
                 [/command]
             [/option]
             [option]


### PR DESCRIPTION
Removing use of [object] prevents object node being written to unit config every
time a glyph is used.

This also allows the transient message to appear after the floating text for more clarity